### PR TITLE
Remove wqy-zenhei from Dockerfile

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -22,10 +22,13 @@ on:
       - '**.adoc'
       - '**.md'
       - 'LICENSE'
+  # Allow to run this workflow manually from the Actions tab:
+  workflow_dispatch:
 
 jobs:
   buildx:
-    if: github.repository_owner == 'astefanutti'
+    # Also build the image from this repository
+    # if: github.repository_owner == 'astefanutti'
     name: buildx
     runs-on: ubuntu-20.04
 
@@ -55,18 +58,18 @@ jobs:
         with:
           images: |
             ghcr.io/${{ github.repository_owner }}/decktape
-          tags: |
-            type=ref,event=branch
-            type=raw,value=latest,enable={{is_default_branch}}
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
+          # tags: |
+          #   type=ref,event=branch
+          #   type=raw,value=latest,enable={{is_default_branch}}
+          #   type=semver,pattern={{version}}
+          #   type=semver,pattern={{major}}.{{minor}}
+          #   type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }}
 
       - name: Build and push
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true # ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,10 +38,7 @@ RUN apk update && apk upgrade && \
     freetype \
     harfbuzz \
     nss \
-    ttf-freefont \
-    wqy-zenhei && \
-    # /etc/fonts/conf.d/44-wqy-zenhei.conf overrides 'monospace' matching FreeMono.ttf in /etc/fonts/conf.d/69-unifont.conf
-    mv /etc/fonts/conf.d/44-wqy-zenhei.conf /etc/fonts/conf.d/74-wqy-zenhei.conf && \
+    ttf-freefont && \
     rm -rf /var/cache/apk/*
 
 # Node.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ FROM alpine:3.19.1
 
 LABEL org.opencontainers.image.source="https://github.com/astefanutti/decktape"
 
-ARG CHROMIUM_VERSION=122.0.6261.94-r0
+ARG CHROMIUM_VERSION=123.0.6312.122-r0
 ENV TERM xterm-color
 
 RUN <<EOF cat > /etc/apk/repositories


### PR DESCRIPTION
Remove wqy-zenhei to avoid font problems

e.g. for "Arial, Helvetica, sans-serif" the font WenQuanYiZenHei was used which looks different and cannot be found by Acrobat Reader in Windows